### PR TITLE
[WIP] Multi-GPU GaaS training workflow

### DIFF
--- a/python/dgl/contrib/cugraph/cugraph_utils.py
+++ b/python/dgl/contrib/cugraph/cugraph_utils.py
@@ -54,7 +54,9 @@ def dglToCugraph(graph):
     dst = edgelist[1]
     src_array = cupy.asarray(src)
     dst_array = cupy.asarray(dst)
-    cudf_data = cudf.DataFrame((src_array, dst_array))
+    
+    cudf_data = cudf.DataFrame({'source':src_array, 'destination': dst_array})
+
     g_cugraph = cugraph.Graph()
     g_cugraph.from_cudf_edgelist(cudf_data)
     return g_cugraph

--- a/python/dgl/contrib/cugraph/gaas_storage.py
+++ b/python/dgl/contrib/cugraph/gaas_storage.py
@@ -15,15 +15,9 @@
 
 import random
 import time
-
-import cupy
 import torch
-import cudf
-import cugraph
-from cugraph.experimental import PropertyGraph
-import dgl
 
-from .cugraph_utils import cugraphToDGL
+import dgl
 
 
 class TorchTensorGaasGraphDataProxy:
@@ -106,11 +100,14 @@ class GaasGraphStorage:
 
     def get_node_storage(self, key, ntype=None):
         raise NotImplementedError
+
         node_col = self.graphstore.get_node_storage(key, ntype)
+        import cupy
         return torch.as_tensor(cupy.asarray(node_col))
 
     def get_edge_storage(self, key, etype=None):
         raise NotImplementedError
+        import cupy
         edge_col = self.graphstore.get_edge_storage(key, etype)
         return torch.as_tensor(cupy.asarray(edge_col))
 
@@ -118,6 +115,7 @@ class GaasGraphStorage:
     @property
     def ntypes(self):
         raise NotImplementedError
+        from cugraph.experimental import PropertyGraph
         data_ntypes = self._ndata[PropertyGraph.type_col_name]
         # TODO: double check the return type
         return data_ntypes
@@ -128,6 +126,7 @@ class GaasGraphStorage:
 
     def etypes(self):
         raise NotImplementedError
+        from cugraph.experimental import PropertyGraph
         data_etypes = self._edata[PropertyGraph.type_col_name]
         return data_etypes
 


### PR DESCRIPTION
This PR resolves https://github.com/rapidsai/graph_dl/issues/3   by creating a multi-GPU GaaS training example

Currently it is failing when deploying on multiple processes. 

My guess is we are not queuing things safely on the `gaas-server` front.  

 

### MRE:
```python
import sys
sys.path.append('../data_loader')
from read_reddit import read_reddit
import torch as th

def run(proc_id, devices, g):
     # Below sets gpu_num
    dev_id = devices[proc_id]

    import numba.cuda as cuda  # Order is very important, do this first before cuda work

    cuda.select_device(
        dev_id
    )  # Create cuda context on the right gpu, defaults to gpu-0
    import cudf #TODO: Maybe dont need to import
    import cugraph #TODO: Maybe dont need to import
    # Start the init_process_group
    th.cuda.set_device(dev_id)
    device = th.device(f"cuda:{dev_id}")

    
    for _ in range(0,5):
        g.sample_neighbors(seed_nodes=[1,2,3],fanout=2)


if __name__ == '__main__':
    dataset_path = "/datasets/vjawa/graphNN/reddit"
    gstore, labels, train_mask, val_mask, test_mask = read_reddit(dataset_path)
    del labels, train_mask, val_mask, test_mask
    devices = [4,5,6] # GPUs to use
    import torch.multiprocessing as mp
    mp.spawn(run, args=[devices, gstore], nprocs=len(devices))
```

### Trace:
```python
 Traceback (most recent call last):
  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
    fn(i, *args)
  File "/home/nfs/vjawa/dgl/dgl/examples/cugraph-pytorch/cugraph-gaas/graphsage/multiprocessing_test.py", line 23, in run
    g.sample_neighbors(seed_nodes=[1,2,3],fanout=2)
  File "/home/nfs/vjawa/dgl/dgl/python/dgl/contrib/cugraph/gaas_storage.py", line 189, in sample_neighbors
    self.__client.extract_subgraph(allow_multi_edges=True,
  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/gaas_client-0.2-py3.8.egg/gaas_client/client.py", line 76, in wrapped_method
    ret_val = method(self, *args, **kwargs)
  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/gaas_client-0.2-py3.8.egg/gaas_client/client.py", line 658, in extract_subgraph
    return self.__client.extract_subgraph(create_using,
  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/thriftpy2/thrift.py", line 219, in _req
    return self._recv(_api)
  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/thriftpy2/thrift.py", line 251, in _recv
    raise v
gaas_thrift.GaasError: GaasError(message='Traceback (most recent call last):\n  File "/home/nfs/vjawa/dgl/GaaS/python/gaas_server/gaas_handler.py", line 278, in extract_subgraph\n    G = pG.extract_subgraph(create_using,\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/cugraph-22.6.0a0+96.gc837aaa45.dirty-py3.8-linux-x86_64.egg/cugraph/structure/property_graph.py", line 639, in extract_subgraph\n    return self.edge_props_to_graph(\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/cugraph-22.6.0a0+96.gc837aaa45.dirty-py3.8-linux-x86_64.egg/cugraph/structure/property_graph.py", line 751, in edge_props_to_graph\n    edge_prop_df[edge_attr] = default_edge_weight\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/contextlib.py", line 75, in inner\n    return func(*args, **kwds)\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/cudf/core/dataframe.py", line 1259, in __setitem__\n    self.insert(len(self._data), arg, value)\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/contextlib.py", line 75, in inner\n    return func(*args, **kwds)\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/cudf/core/dataframe.py", line 2616, in insert\n    return self._insert(\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/contextlib.py", line 75, in inner\n    return func(*args, **kwds)\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/cudf/core/dataframe.py", line 2692, in _insert\n    self._data.insert(name, value, loc=loc)\n  File "/datasets/vjawa/miniconda3/envs/cugraph_dev/lib/python3.8/site-packages/cudf/core/column_accessor.py", line 290, in insert\n    raise ValueError(f"Cannot insert \'{name}\', already exists")\nValueError: Cannot insert \'_WEIGHT_2\', already exists\n')
```

### Related PR:

See  related PR that does Multi GPU CuGraphStorage based Sampling (Successfully) 

https://github.com/rapidsai/dgl/pull/10 